### PR TITLE
Bug fix/9th move display error

### DIFF
--- a/game.js
+++ b/game.js
@@ -5,25 +5,6 @@ class Game {
     this.currentMove = 0;
   };
 
-  takeTurn(position) {
-    this.currentMove++;
-    if (this.currentMove % 2 !== 0) {
-      this.player1.positions.push(position);
-      this.checkGame(this.player1);
-    } else {
-      var position = parseInt(event.target.name);
-        this.player2.positions.push(position);
-        this.checkGame(this.player2);
-    };
-  };
-
-  makeNewPlayers() {
-    currentGame.player1 = new Player('1', 'x');
-    currentGame.player1.retrieveWinsFromStorage();
-    currentGame.player2 = new Player('2', 'o');
-    currentGame.player2.retrieveWinsFromStorage();
-  };
-
   checkGame(player) {
     updateCurrentPlayerDisplay();
     var winner = player.id;
@@ -45,10 +26,6 @@ class Game {
         player.saveToStorage();
         showPlayerWin(winner);
         setTimeout(function(){currentGame.clearGame(); }, 3000);
-      } else if (this.currentMove >= 9) {
-        updateCurrentPlayerDisplay();
-        setTimeout(function(){currentGame.clearGame(); }, 3000);
-      } else {
       };
     };
   };
@@ -58,4 +35,25 @@ class Game {
     showNewGame();
     refreshGameBoard();
   };
+
+
+  makeNewPlayers() {
+    currentGame.player1 = new Player('1', 'x');
+    currentGame.player1.retrieveWinsFromStorage();
+    currentGame.player2 = new Player('2', 'o');
+    currentGame.player2.retrieveWinsFromStorage();
+  };
+
+  takeTurn(position) {
+    this.currentMove++;
+    if (this.currentMove % 2 !== 0) {
+      this.player1.positions.push(position);
+      this.checkGame(this.player1);
+    } else {
+      var position = parseInt(event.target.name);
+      this.player2.positions.push(position);
+      this.checkGame(this.player2);
+    };
+  };
+
 };

--- a/main.js
+++ b/main.js
@@ -55,6 +55,7 @@ function refreshGameBoard() {
 
 function showDraw() {
   currentPlayerDisplay.innerText = 'Its a DRAW';
+  setTimeout(function(){currentGame.clearGame(); }, 3000);
 };
 
 function showIcon(position) {


### PR DESCRIPTION
# Thank you for pushing your code!

## What (if any) features are you implementing?
 + There was a bug in my code that would show up on the 9th move of a game. If the 9th and final move was a winning move, the display would show a draw instead of show which player won (though the other functionality of a winning game would still work, for example the win-count would still increment and be saved/retrieved from local storage.)

## What (if anything) did you refactor?
 + In order to fix this, I had to refactor the checkGame() method in my game.js file. Originally I had it check if the player instance's positions array matched any of the win scenarios array. If they didn't match, it would get kicked to an else if statement to determine if it were a draw. This is what confused the game, so I simply removed the else if and let the updateCurrentPlayerDisplay() function handle the determination.


## Were there any issues that arose?
 + No


## Any other comments, questions, or concerns?
 + As far as I can tell, this was the last bug in playability. At this point you are clear to either add functionality, or refine the CSS design! Great work!
