### PR TITLE
Add an invokation of toggle pointer inside the show draw function

### DIFF
--- a/main.js
+++ b/main.js
@@ -55,6 +55,7 @@ function refreshGameBoard() {
 
 function showDraw() {
   currentPlayerDisplay.innerText = 'Its a DRAW';
+  togglePointer();
   setTimeout(function(){currentGame.clearGame(); }, 3000);
 };
 


### PR DESCRIPTION
# Thank you for pushing your code!

## What (if any) features are you implementing?
 + This branch fixes a bug that arose after I designed the togglePointer() helper function. It was not being triggered when there was a draw, only upon a win. This meant that after a draw game, togglePointer() would be invoked on the clearGame() method, and the new game board would be un-clickable.
 + The fix was quite simple (hence only one commit)- I simply had to invoke the togglePointer helper function within the showDraw() function. This balances out the invokation in the clear game.

## What (if anything) did you refactor?
 + The showDraw() function.


## Were there any issues that arose?
 + NA


## Any other comments, questions, or concerns?
 + I still need to figure out the best accessibility option for the game board buttons so they are readable by screen readers.
